### PR TITLE
Complete functionality in functional rewrite (no pun intended)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 dist
 .idea
 coverage
+*.env*
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug .env lexer",
+            "type": "node",
+            "request": "launch",
+            "runtimeArgs": [
+                "--inspect-brk",
+                "${workspaceRoot}/node_modules/.bin/jest",
+                "--runInBand",
+                "./test/unit/lib/env/lexer.test.ts"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "port": 9229
+        }
+    ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,47 +1,21 @@
 import readline from "readline"
 import fs from "fs"
-import { getOptionsFromRawArguments, Options } from "lib/options"
+import { getOptionsFromRawArguments } from "lib/options"
 import { makeStdIoReader } from "lib/std-io-reader"
 import { makeCliPrompter } from "lib/cli"
-import { analyzeEnvSourceCode, Token } from "lib/env/lexer"
+import { analyzeEnvSourceCode } from "lib/env/lexer"
 import { parseEnvTokens } from "lib/env/parser"
+import { render } from "lib/env/renderer"
+import { makeMerge } from "lib/env/merger"
+
 const stdIoReader = makeStdIoReader(() => readline.createInterface(process.stdin, process.stdout))
 const cliPrompter = makeCliPrompter(console, stdIoReader)
-
-type NodeFs = Pick<typeof fs, 'existsSync' | 'readFileSync'>
-
-const ENCODING = 'utf8'
-
-const analyzeDistEnvFile = ({ distFilePath: path }: Options): Token[] => {
-    const exists = fs.existsSync(path)
-    if (!exists) throw new Error(`Could not locate ${path}`)
-
-    const src = fs.readFileSync(path, { encoding: ENCODING }).toString()
-    return analyzeEnvSourceCode(src)
-}
-
-const analyzeLocalFile = ({ localFilePath: path }: Options): Token[] => {
-    const exists = fs.existsSync(path)
-    if (!exists) return []
-
-    const src = fs.readFileSync(path, { encoding: ENCODING }).toString()
-    return analyzeEnvSourceCode(src)
-}
+const merge = makeMerge(cliPrompter, analyzeEnvSourceCode, parseEnvTokens, render, fs)
 
 const main = async () => {
     try {
         const options = getOptionsFromRawArguments(process.argv)
-        const distFileTokens = analyzeDistEnvFile(options)
-        const parsedEnvDocument = parseEnvTokens(distFileTokens)
-        console.log(JSON.stringify(parsedEnvDocument.abstractSyntaxTree))
-
-        // const localFileTokens = analyzeLocalFile(options)
-        
-        // console.log(distFileTokens)
-        // console.log(localFileTokens)
-
-        // const environmentVariable = await cliPrompter.promptUserForEnvironmentVariable({ name: 'DB_USER', value: 'my dude' })
-        // console.log({ environmentVariable })
+        await merge(options)
     } catch (e) {
         cliPrompter.printError(e)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import readline from "readline"
 import fs from "fs"
-import { getOptionsFromRawArguments } from "lib/options"
+import { getOptionsFromEnvironment } from "lib/options"
 import { makeStdIoReader } from "lib/std-io-reader"
 import { makeCliPrompter } from "lib/cli"
 import { analyzeEnvSourceCode } from "lib/env/lexer"
@@ -14,7 +14,7 @@ const merge = makeMerge(cliPrompter, analyzeEnvSourceCode, parseEnvTokens, rende
 
 const main = async () => {
     try {
-        const options = getOptionsFromRawArguments(process.argv)
+        const options = getOptionsFromEnvironment(process.argv, process.env)
         await merge(options)
     } catch (e) {
         cliPrompter.printError(e)

--- a/src/lib/env/lexer.ts
+++ b/src/lib/env/lexer.ts
@@ -24,6 +24,7 @@ const COMMENT_EXPRESSION = /^#$/
 const IDENTIFIER_START_EXPRESSION = /^[a-zA-Z]$/
 const IDENTIFIER_END_EXPRESSION = /^[^a-zA-Z0-9_-]$/
 
+export type AnalyzeEnvSourceCode = typeof analyzeEnvSourceCode
 export const analyzeEnvSourceCode = (src: string): Token[] => {
     const tokens: Token[] = []
     for (let i = 0; i < src.length;) {

--- a/src/lib/env/lexer.ts
+++ b/src/lib/env/lexer.ts
@@ -1,3 +1,5 @@
+import { QuoteType } from "lib/env/parser"
+
 export enum TokenType {
     identifier = 'identifier',
     operator = 'operator',
@@ -38,8 +40,9 @@ export const analyzeEnvSourceCode = (src: string): Token[] => {
 const getTokenAtPosition = (src: string, position: number, tokens: Token[]): Token => {
     const firstChar = src[position]
 
-    const isQuotedLiteral = isLastTokenOpeningQuote(tokens)
-    const isDoubleQuotedLiteral = isQuotedLiteral && tokens[tokens.length - 1].value === '"'
+    const [previousToken, secondPreviousToken] = getPreviousTwoNonWhitespaceTokens(tokens)
+    const isQuotedLiteral = isInsideQuotes(previousToken, secondPreviousToken)
+    const isDoubleQuotedLiteral = isQuotedLiteral && previousToken.value === QuoteType.double
 
     if (!isDoubleQuotedLiteral) {
         const isNewline = firstChar === '\n'
@@ -57,6 +60,7 @@ const getTokenAtPosition = (src: string, position: number, tokens: Token[]): Tok
         if (isWhiteSpace) return makeWhiteSpaceToken(position, src, tokens)
 
         const isQuote = QUOTE_EXPRESSION.test(firstChar)
+        // TODO escaped quotes?
         if (isQuote) return makeQuoteToken(position, src, tokens)
 
         const isOperator = OPERATOR_EXPRESSION.test(firstChar)
@@ -159,11 +163,29 @@ const makeOperatorToken = (position: number, src: string, tokens: Token[]): Toke
     value: src[position]
 })
 
+const isInsideQuotes = (previousToken?: Token, secondPreviousToken?: Token): boolean => {
+    if (!previousToken || !secondPreviousToken) return false
+
+    const hasOpeningQuote = previousToken.type === TokenType.quote
+    const isSecondPreviousTokenQuote = secondPreviousToken.type === TokenType.quote
+    const isSecondPreviousTokenLiteral = secondPreviousToken.type === TokenType.literal
+    const hasTerminatingQuote = isSecondPreviousTokenQuote || isSecondPreviousTokenLiteral
+
+    return hasOpeningQuote && !hasTerminatingQuote
+}
+
 const makeLiteralToken = (position: number, src: string, tokens: Token[]): Token => {
     let i = position
     let value = src[i++]
-    const previousToken = getLastNonWhiteSpaceToken(tokens)
+
+    const [previousToken] = getPreviousTwoNonWhitespaceTokens(tokens)
     const isQuotedValue = previousToken.type === TokenType.quote
+    const firstChar = value
+    const isClosingQuote = firstChar === previousToken?.value
+    const isEmptyQuotedValue = isQuotedValue && isClosingQuote
+
+    if (isEmptyQuotedValue) return makeQuoteToken(position, src, tokens)
+
     for (; i < src.length; i++) {
         const char = src[i]
         const isClosingQuote = char === previousToken.value
@@ -217,15 +239,24 @@ const makeIdentifierToken = (position: number, src: string, tokens: Token[]): To
     }
 }
 
-const getLastNonWhiteSpaceToken = (previousTokens: Token[]): Token | null => {
-    for (let i = previousTokens.length - 1; i >= 0; i--) {
-        const token = previousTokens[i]
+const getPreviousTwoNonWhitespaceTokens = (tokens: Token[]): [Token?, Token?] => {
+    let previousToken: Token = null
+    let secondPreviousToken: Token = null
+
+    for (let i = tokens.length - 1; i >= 0; i--) {
+        const token = tokens[i]
         const isWhiteSpace = token.type === TokenType.whitespace
         if (!isWhiteSpace) {
-            return token
+            const hasPreviousToken = !!previousToken
+            if (hasPreviousToken) {
+                secondPreviousToken = token
+                break
+            }
+            previousToken = token
         }
     }
-    return null
+
+    return [previousToken, secondPreviousToken]
 }
 
 const hasAssignmentOperatorOnCurrentLine = (previousTokens: Token[]): boolean => {
@@ -248,11 +279,3 @@ const hasAssignmentOperatorOnCurrentLine = (previousTokens: Token[]): boolean =>
 
 const isLastTokenComment = (previousTokens: Token[]): boolean =>
     previousTokens.length > 0 && previousTokens[previousTokens.length - 1].type === TokenType.comment
-
-const isLastTokenOpeningQuote = (previousTokens: Token[]): boolean => {
-    const isLastTokenQuote =
-        previousTokens.length > 0 && previousTokens[previousTokens.length - 1].type === TokenType.quote
-    const isSecondToLastTokenLiteral =
-        previousTokens.length > 1 && previousTokens[previousTokens.length - 2].type === TokenType.literal
-    return isLastTokenQuote && !isSecondToLastTokenLiteral
-}

--- a/src/lib/env/merger.ts
+++ b/src/lib/env/merger.ts
@@ -1,0 +1,175 @@
+import { CliPrompter } from "lib/cli";
+import { Token, AnalyzeEnvSourceCode } from "lib/env/lexer";
+import {
+  ParsedEnvDocument,
+  ParseEnvTokens,
+  VariableDeclarationNode,
+  RawLiteralNode,
+  QuotedLiteralNode,
+  NodeType,
+  IdentifierNode,
+  QuoteType,
+  NewlineNode,
+} from "lib/env/parser";
+import { Render } from "lib/env/renderer";
+import fs from "fs";
+import { Options } from "lib/options";
+
+type NodeFs = Pick<typeof fs, "existsSync" | "readFileSync" | "writeFileSync">;
+
+export type Merge = ReturnType<typeof makeMerge>;
+export const makeMerge = (
+  cliPrompter: CliPrompter,
+  analyzeEnvSourceCode: AnalyzeEnvSourceCode,
+  parseEnvTokens: ParseEnvTokens,
+  render: Render,
+  fs: NodeFs
+) => {
+  const ENCODING = "utf8";
+
+  const merge = async (options: Options) => {
+    const distDocument = parseDistDocument(options);
+    const localDocument = parseLocalDocument(options);
+    const mergedDocument = await mergeDocuments(distDocument, localDocument);
+
+    writeLocalEnvFile(options, mergedDocument);
+  };
+
+  const analyzeDistEnvFile = ({ distFilePath: path }: Options): Token[] => {
+    const exists = fs.existsSync(path);
+    if (!exists) throw new Error(`Could not locate ${path}`);
+
+    const src = fs.readFileSync(path, { encoding: ENCODING }).toString();
+    return analyzeEnvSourceCode(src);
+  };
+
+  const analyzeLocalEnvFile = ({ localFilePath: path }: Options): Token[] => {
+    const exists = fs.existsSync(path);
+    if (!exists) return [];
+
+    const src = fs.readFileSync(path, { encoding: ENCODING }).toString();
+    return analyzeEnvSourceCode(src);
+  };
+
+  const writeLocalEnvFile = (
+    { localFilePath: path }: Options,
+    document: ParsedEnvDocument
+  ) => {
+    const fileContent = render(document.abstractSyntaxTree);
+    fs.writeFileSync(path, fileContent, { encoding: ENCODING });
+  };
+
+  const mergeDocuments = async (
+    distributedDocument: ParsedEnvDocument,
+    localDocument: ParsedEnvDocument
+  ): Promise<ParsedEnvDocument> => {
+    const newLocalDocument: ParsedEnvDocument = { ...localDocument };
+
+    // TODO add environment check thing
+    let hasBeenPrompted = false;
+
+    const variableNames = Object.keys(distributedDocument.variablesByName);
+    for (const name of variableNames) {
+      const existsLocally = name in localDocument.variablesByName;
+      if (existsLocally) continue;
+
+      if (!hasBeenPrompted) {
+        cliPrompter.promptUserAboutNewVariables();
+        hasBeenPrompted = true;
+      }
+
+      const distributedVariable = distributedDocument.variablesByName[name];
+      const defaultValue = getValueFromVariable(distributedVariable);
+      const { value } = await cliPrompter.promptUserForEnvironmentVariable({
+        name,
+        value: defaultValue,
+      });
+      const variable = createVariableDeclaration(name, value);
+      addVariableToDocument(variable, newLocalDocument);
+    }
+
+    return newLocalDocument;
+  };
+
+  const parseDistDocument = (options: Options): ParsedEnvDocument => {
+    const tokens = analyzeDistEnvFile(options);
+    return parseEnvTokens(tokens);
+  };
+
+  const parseLocalDocument = (options: Options): ParsedEnvDocument => {
+    const tokens = analyzeLocalEnvFile(options);
+    return parseEnvTokens(tokens);
+  };
+
+  return merge;
+};
+
+const addVariableToDocument = (
+  variable: VariableDeclarationNode,
+  document: ParsedEnvDocument
+) => {
+  document.abstractSyntaxTree.statements.push(variable);
+
+  const newline: NewlineNode = { type: NodeType.newline };
+  document.abstractSyntaxTree.statements.push(newline);
+
+  const { name } = variable.identifier;
+  document.variablesByName[name] = variable;
+};
+
+const getValueFromVariable = (variable: VariableDeclarationNode): string => {
+  const hasValue = !!variable.value;
+  if (!hasValue) return "";
+
+  const hasRawLiteral = variable.value.type === NodeType.literal;
+  if (hasRawLiteral) {
+    const rawLiteral = variable.value as RawLiteralNode;
+    return rawLiteral.value;
+  }
+
+  const quotedLiteral = variable.value as QuotedLiteralNode;
+  const hasContent = !!quotedLiteral.content;
+  if (!hasContent) return "";
+
+  return quotedLiteral.content.value;
+};
+
+const createVariableDeclaration = (
+  name: string,
+  value: string
+): VariableDeclarationNode => {
+  const identifier: IdentifierNode = { type: NodeType.identifier, name };
+  const isEmpty = !value;
+  if (isEmpty) return { type: NodeType.variableDeclaration, identifier };
+
+  const hasSingleQuotes = value.indexOf("'") > -1;
+  const hasDoubleQuotes = value.indexOf('"') > -1;
+  const isQuoted = hasSingleQuotes || hasDoubleQuotes;
+  if (isQuoted) {
+    const hasSingleAndDoubleQuotes = hasSingleQuotes && hasDoubleQuotes;
+    const quoteType =
+      hasSingleAndDoubleQuotes || hasSingleQuotes
+        ? QuoteType.double
+        : QuoteType.single;
+    const valueWithEscapedDoubleQuotes = value.replace(/"/g, '\\"');
+
+    const rawLiteral: RawLiteralNode = {
+      type: NodeType.literal,
+      value: hasSingleAndDoubleQuotes ? valueWithEscapedDoubleQuotes : value,
+    };
+
+    const quotedLiteral: QuotedLiteralNode = {
+      type: NodeType.quotedLiteral,
+      quoteType,
+      content: rawLiteral,
+    };
+    return {
+      type: NodeType.variableDeclaration,
+      identifier,
+      value: quotedLiteral,
+    };
+  }
+
+  const rawLiteral: RawLiteralNode = { type: NodeType.literal, value };
+  return { type: NodeType.variableDeclaration, identifier, value: rawLiteral };
+};

--- a/src/lib/env/parser.ts
+++ b/src/lib/env/parser.ts
@@ -58,6 +58,7 @@ export interface ParsedEnvDocument {
     abstractSyntaxTree: DocumentNode
 }
 
+export type ParseEnvTokens = typeof parseEnvTokens
 export const parseEnvTokens = (tokens: Token[]): ParsedEnvDocument => {
     const document: DocumentNode = {
         type: NodeType.document,

--- a/src/lib/env/parser.ts
+++ b/src/lib/env/parser.ts
@@ -1,6 +1,6 @@
 import { getColumn, getLine, Token, TokenType } from "lib/env/lexer"
 
-enum NodeType {
+export enum NodeType {
     literal = 'literal',
     quotedLiteral = 'quotedLiteral',
     identifier = 'identifier',
@@ -10,44 +10,44 @@ enum NodeType {
     document = 'document'
 }
 
-enum QuoteType {
+export enum QuoteType {
     single = '\'',
     double = '"'
 }
 
-interface Node {
+export interface Node {
     type: NodeType
 }
 
-interface RawLiteralNode extends Node {
+export interface RawLiteralNode extends Node {
     value: string
 }
 
-interface QuotedLiteralNode extends Node {
+export interface QuotedLiteralNode extends Node {
     quoteType: QuoteType
     content: RawLiteralNode|null
 }
 
-type LiteralNode = RawLiteralNode | QuotedLiteralNode
+export type LiteralNode = RawLiteralNode | QuotedLiteralNode
 
-interface IdentifierNode extends Node {
+export interface IdentifierNode extends Node {
     name: string
 }
 
-interface VariableDeclarationNode extends Node {
+export interface VariableDeclarationNode extends Node {
     identifier: IdentifierNode
     value?: LiteralNode
 }
 
-interface CommentNode extends Node {
+export interface CommentNode extends Node {
     body: string|null
 }
 
-interface NewlineNode extends Node {}
+export interface NewlineNode extends Node {}
 
-type StatementNode = NewlineNode | CommentNode | VariableDeclarationNode
+export type StatementNode = NewlineNode | CommentNode | VariableDeclarationNode
 
-interface DocumentNode extends Node {
+export interface DocumentNode extends Node {
     statements: StatementNode[]
 }
 

--- a/src/lib/env/renderer.ts
+++ b/src/lib/env/renderer.ts
@@ -1,0 +1,54 @@
+import {
+  DocumentNode,
+  StatementNode,
+  NodeType,
+  VariableDeclarationNode,
+  IdentifierNode,
+  LiteralNode,
+  RawLiteralNode,
+  QuotedLiteralNode,
+  CommentNode,
+} from "lib/env/parser";
+
+export const render = (abstractSyntaxTree: DocumentNode): string =>
+  abstractSyntaxTree.statements.map(renderStatement).join("");
+
+const renderStatement = (node?: StatementNode) => {
+  const isVariableDeclaration = node.type === NodeType.variableDeclaration;
+  if (isVariableDeclaration)
+    return renderVariableDeclaration(node as VariableDeclarationNode);
+
+  const isNewline = node.type === NodeType.newline;
+  if (isNewline) return "\n";
+
+  return renderComment(node as CommentNode);
+};
+
+const renderVariableDeclaration = ({
+  identifier,
+  value,
+}: VariableDeclarationNode): string =>
+  `${renderIdentifier(identifier)}=${renderLiteral(value)}`;
+
+const renderIdentifier = ({ name }: IdentifierNode): string => name;
+
+const renderLiteral = (literal?: LiteralNode): string => {
+  const isEmpty = !literal;
+  if (isEmpty) return "";
+
+  const isRawLiteral = literal.type === NodeType.literal;
+  if (isRawLiteral) return renderRawLiteral(literal as RawLiteralNode);
+
+  return renderQuotedLiteral(literal as QuotedLiteralNode);
+};
+
+const renderRawLiteral = ({ value }: RawLiteralNode): string => value;
+
+const renderQuotedLiteral = ({
+  quoteType,
+  content,
+}: QuotedLiteralNode): string =>
+  `${quoteType}${renderRawLiteral(content)}${quoteType}`;
+
+const renderComment = ({ body }: CommentNode): string =>
+  `#${!!body ? body : ""}`;

--- a/src/lib/env/renderer.ts
+++ b/src/lib/env/renderer.ts
@@ -3,13 +3,13 @@ import {
   StatementNode,
   NodeType,
   VariableDeclarationNode,
-  IdentifierNode,
   LiteralNode,
   RawLiteralNode,
   QuotedLiteralNode,
   CommentNode,
 } from "lib/env/parser";
 
+export type Render = typeof render
 export const render = (abstractSyntaxTree: DocumentNode): string =>
   abstractSyntaxTree.statements.map(renderStatement).join("");
 
@@ -28,27 +28,27 @@ const renderVariableDeclaration = ({
   identifier,
   value,
 }: VariableDeclarationNode): string =>
-  `${renderIdentifier(identifier)}=${renderLiteral(value)}`;
-
-const renderIdentifier = ({ name }: IdentifierNode): string => name;
+  `${identifier.name}=${renderLiteral(value)}`;
 
 const renderLiteral = (literal?: LiteralNode): string => {
   const isEmpty = !literal;
   if (isEmpty) return "";
 
   const isRawLiteral = literal.type === NodeType.literal;
-  if (isRawLiteral) return renderRawLiteral(literal as RawLiteralNode);
+  if (isRawLiteral) return (literal as RawLiteralNode).value
 
   return renderQuotedLiteral(literal as QuotedLiteralNode);
 };
 
-const renderRawLiteral = ({ value }: RawLiteralNode): string => value;
-
 const renderQuotedLiteral = ({
   quoteType,
   content,
-}: QuotedLiteralNode): string =>
-  `${quoteType}${renderRawLiteral(content)}${quoteType}`;
+}: QuotedLiteralNode): string => {
+    const isEmpty = !content
+    const value = isEmpty ? '' : content.value
+
+    return `${quoteType}${value}${quoteType}`;
+}
 
 const renderComment = ({ body }: CommentNode): string =>
   `#${!!body ? body : ""}`;

--- a/test/unit/lib/env/lexer.test.ts
+++ b/test/unit/lib/env/lexer.test.ts
@@ -1,164 +1,409 @@
-import { analyzeEnvSourceCode, Token } from "../../../../src/lib/env/lexer"
+import { analyzeEnvSourceCode, Token, TokenType } from "../../../../src/lib/env/lexer"
 
 describe('.env lexer', () => {
-    describe('comments', () => {
-        test('that no tokens are analyzed from empty files', () => {
-            const envFile = ''
-            const tokens = analyzeEnvSourceCode(envFile)
-            expect(tokens).toEqual([])
-        })
-
-        test('that comments with no body are analyzed', () => {
-            const envFile = '#'
-            const tokens = analyzeEnvSourceCode(envFile)
-            expect(tokens).toEqual([
-                { type: 'comment', position: 0, line: 1, column: 1, length: 1, value: '#' }
-            ] as Token[])
-        })
-
-        test('that comments with a body are analyzed', () => {
-            const envFile = '# hello world'
-            const tokens = analyzeEnvSourceCode(envFile)
-            expect(tokens).toEqual([
-                { type: 'comment', position: 0, line: 1, column: 1, length: 1, value: '#' },
-                { type: 'commentBody', position: 1, line: 1, column: 2, length: 12, value: ' hello world' }
-            ] as Token[])
-        })
-
-        test("that comment bodies don't need to start with a white space", () => {
-            const envFile = '#lol'
-            const tokens = analyzeEnvSourceCode(envFile)
-            expect(tokens).toEqual([
-                { type: 'comment', position: 0, line: 1, column: 1, length: 1, value: '#' },
-                { type: 'commentBody', position: 1, line: 1, column: 2, length: 3, value: 'lol' }
-            ] as Token[])
-        })
-
-        test('that comments can come after spaces', () => {
-            const envFile = '    #comment after space'
-            const tokens = analyzeEnvSourceCode(envFile)
-            expect(tokens).toEqual([
-                { type: 'whitespace', position: 0, line: 1, column: 1, length: 1, value: ' ' },
-                { type: 'whitespace', position: 1, line: 1, column: 2, length: 1, value: ' ' },
-                { type: 'whitespace', position: 2, line: 1, column: 3, length: 1, value: ' ' },
-                { type: 'whitespace', position: 3, line: 1, column: 4, length: 1, value: ' ' },
-                { type: 'comment', position: 4, line: 1, column: 5, length: 1, value: '#' },
-                { type: 'commentBody', position: 5, line: 1, column: 6, length: 19, value: 'comment after space' }
-            ] as Token[])
-        })
-
-        test('that comments only span one line', () => {
-            const envFile = 
-`# hello world
-test`
-            const tokens = analyzeEnvSourceCode(envFile)
-            expect(tokens).toEqual([
-                { type: 'comment', position: 0, line: 1, column: 1, length: 1, value: '#' },
-                { type: 'commentBody', position: 1, line: 1, column: 2, length: 12, value: ' hello world' },
-                { type: 'newline', position: 13, line: 1, column: 14, length: 1, value: '\n' },
-                { type: 'identifier', position: 14, line: 2, column: 1, length: 4, value: 'test' }
-            ] as Token[])
-        })
-
-        test('that comments can come after other tokens', () => {
-            const envFile = 'test # comment that is after'
-            const tokens = analyzeEnvSourceCode(envFile)
-            expect(tokens).toEqual([
-                { type: 'identifier', position: 0, line: 1, column: 1, length: 4, value: 'test' },
-                { type: 'whitespace', position: 4, line: 1, column: 5, length: 1, value: ' ' },
-                { type: 'comment', position: 5, line: 1, column: 6, length: 1, value: '#' },
-                { type: 'commentBody', position: 6, line: 1, column: 7, length: 22, value: ' comment that is after' }
-            ] as Token[])
-        })
+  describe('comments', () => {
+    test('that no tokens are analyzed from empty files', () => {
+      const envFile = ''
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([])
     })
 
-    describe('variable assignment', () => {
-        test('identifiers can be assigned to simple literals', () => {
-            const envFile = 'foo=bar'
-            const tokens = analyzeEnvSourceCode(envFile)
-            expect(tokens).toEqual([
-                { type: 'identifier', position: 0, line: 1, column: 1, length: 3, value: 'foo' },
-                { type: 'operator', position: 3, line: 1, column: 4, length: 1, value: '=' },
-                { type: 'literal', position: 4, line: 1, column: 5, length: 3, value: 'bar' }
-            ] as Token[])
-        })
+    test('that comments with no body are analyzed', () => {
+      const envFile = '#'
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([
+        { type: 'comment', position: 0, line: 1, column: 1, length: 1, value: '#' }
+      ] as Token[])
+    })
 
-        test('that values can be single quoted', () => {
-            const envFile = `this='has "double quotes" in the value'`
-            const tokens = analyzeEnvSourceCode(envFile)
-            expect(tokens).toEqual([
-                { type: 'identifier', position: 0, line: 1, column: 1, length: 4, value: 'this' },
-                { type: 'operator', position: 4, line: 1, column: 5, length: 1, value: '=' },
-                { type: 'quote', position: 5, line: 1, column: 6, length: 1, value: "'" },
-                { type: 'literal', position: 6, line: 1, column: 7, length: 32, value: 'has "double quotes" in the value' },
-                { type: 'quote', position: 38, line: 1, column: 39, length: 1, value: "'" }
-            ] as Token[])
-        })
+    test('that comments with a body are analyzed', () => {
+      const envFile = '# hello world'
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([
+        { type: 'comment', position: 0, line: 1, column: 1, length: 1, value: '#' },
+        { type: 'commentBody', position: 1, line: 1, column: 2, length: 12, value: ' hello world' }
+      ] as Token[])
+    })
 
-        test('that multi-line values can be double quoted', () => {
-            const envFile = 
-`this="{
+    test("that comment bodies don't need to start with a white space", () => {
+      const envFile = '#lol'
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([
+        { type: 'comment', position: 0, line: 1, column: 1, length: 1, value: '#' },
+        { type: 'commentBody', position: 1, line: 1, column: 2, length: 3, value: 'lol' }
+      ] as Token[])
+    })
+
+    test('that comments can come after spaces', () => {
+      const envFile = '    #comment after space'
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([
+        { type: 'whitespace', position: 0, line: 1, column: 1, length: 1, value: ' ' },
+        { type: 'whitespace', position: 1, line: 1, column: 2, length: 1, value: ' ' },
+        { type: 'whitespace', position: 2, line: 1, column: 3, length: 1, value: ' ' },
+        { type: 'whitespace', position: 3, line: 1, column: 4, length: 1, value: ' ' },
+        { type: 'comment', position: 4, line: 1, column: 5, length: 1, value: '#' },
+        { type: 'commentBody', position: 5, line: 1, column: 6, length: 19, value: 'comment after space' }
+      ] as Token[])
+    })
+
+    test('that comments only span one line', () => {
+      const envFile =
+        `# hello world
+test`
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([
+        { type: 'comment', position: 0, line: 1, column: 1, length: 1, value: '#' },
+        { type: 'commentBody', position: 1, line: 1, column: 2, length: 12, value: ' hello world' },
+        { type: 'newline', position: 13, line: 1, column: 14, length: 1, value: '\n' },
+        { type: 'identifier', position: 14, line: 2, column: 1, length: 4, value: 'test' }
+      ] as Token[])
+    })
+
+    test('that comments can come after other tokens', () => {
+      const envFile = 'test # comment that is after'
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([
+        { type: 'identifier', position: 0, line: 1, column: 1, length: 4, value: 'test' },
+        { type: 'whitespace', position: 4, line: 1, column: 5, length: 1, value: ' ' },
+        { type: 'comment', position: 5, line: 1, column: 6, length: 1, value: '#' },
+        { type: 'commentBody', position: 6, line: 1, column: 7, length: 22, value: ' comment that is after' }
+      ] as Token[])
+    })
+  })
+
+  describe('variable assignment', () => {
+    test('identifiers can be assigned to simple literals', () => {
+      const envFile = 'foo=bar'
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([
+        { type: 'identifier', position: 0, line: 1, column: 1, length: 3, value: 'foo' },
+        { type: 'operator', position: 3, line: 1, column: 4, length: 1, value: '=' },
+        { type: 'literal', position: 4, line: 1, column: 5, length: 3, value: 'bar' }
+      ] as Token[])
+    })
+
+    test('that values can be single quoted', () => {
+      const envFile = `this='has "double quotes" in the value'`
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([
+        { type: 'identifier', position: 0, line: 1, column: 1, length: 4, value: 'this' },
+        { type: 'operator', position: 4, line: 1, column: 5, length: 1, value: '=' },
+        { type: 'quote', position: 5, line: 1, column: 6, length: 1, value: "'" },
+        { type: 'literal', position: 6, line: 1, column: 7, length: 32, value: 'has "double quotes" in the value' },
+        { type: 'quote', position: 38, line: 1, column: 39, length: 1, value: "'" }
+      ] as Token[])
+    })
+
+    test('that multi-line values can be double quoted', () => {
+      const envFile =
+        `this="{
     is: {
         a: ['multi-line', 'json', 'string']
     }
 }"`
-            const tokens = analyzeEnvSourceCode(envFile)
-            expect(tokens).toEqual([
-                { type: 'identifier', position: 0, line: 1, column: 1, length: 4, value: 'this' },
-                { type: 'operator', position: 4, line: 1, column: 5, length: 1, value: '=' },
-                { type: 'quote', position: 5, line: 1, column: 6, length: 1, value: '"' },
-                { type: 'literal', position: 6, line: 1, column: 7, length: 63, value: `{\n    is: {\n        a: ['multi-line', 'json', 'string']\n    }\n}` },
-                { type: 'quote', position: 69, line: 1, column: 70, length: 1, value: '"' }
-            ] as Token[])
-        })
-
-        test('that comments cannot exist in quoted literals', () => {
-            const envFile = 
-`valA="#a comment"
-valB='# another one'`
-            const tokens = analyzeEnvSourceCode(envFile)
-            expect(tokens).toEqual([
-                { type: 'identifier', position: 0, line: 1, column: 1, length: 4, value: 'valA' },
-                { type: 'operator', position: 4, line: 1, column: 5, length: 1, value: '=' },
-                { type: 'quote', position: 5, line: 1, column: 6, length: 1, value: '"' },
-                { type: 'literal', position: 6, line: 1, column: 7, length: 10, value: '#a comment' },
-                { type: 'quote', position: 16, line: 1, column: 17, length: 1, value: '"' },
-                { type: 'newline', position: 17, line: 1, column: 18, length: 1, value: '\n' },
-                { type: 'identifier', position: 18, line: 2, column: 1, length: 4, value: 'valB' },
-                { type: 'operator', position: 22, line: 2, column: 5, length: 1, value: '=' },
-                { type: 'quote', position: 23, line: 2, column: 6, length: 1, value: "'" },
-                { type: 'literal', position: 24, line: 2, column: 7, length: 13, value: '# another one' },
-                { type: 'quote', position: 37, line: 2, column: 20, length: 1, value: "'" }
-            ] as Token[])
-        })
-
-        test('that comments can exist on the same line as a variable assignment', () => {
-            const envFile = 'foo=bar # hello world'
-            const tokens = analyzeEnvSourceCode(envFile)
-            expect(tokens).toEqual([
-                { type: 'identifier', position: 0, line: 1, column: 1, length: 3, value: 'foo' },
-                { type: 'operator', position: 3, line: 1, column: 4, length: 1, value: '=' },
-                { type: 'literal', position: 4, line: 1, column: 5, length: 3, value: 'bar' },
-                { type: 'whitespace', position: 7, line: 1, column: 8, length: 1, value: ' ' },
-                { type: 'comment', position: 8, line: 1, column: 9, length: 1, value: '#' },
-                { type: 'commentBody', position: 9, line: 1, column: 10, length: 12, value: ' hello world' }
-            ] as Token[])
-        })
-
-        test('that newlines terminate variable assignment when the literal value is unqouted', () => {
-            const envFile =
-`foo=test123
-bar=test456`
-            const tokens = analyzeEnvSourceCode(envFile)
-            expect(tokens).toEqual([
-                { type: 'identifier', position: 0, line: 1, column: 1, length: 3, value: 'foo' },
-                { type: 'operator', position: 3, line: 1, column: 4, length: 1, value: '=' },
-                { type: 'literal', position: 4, line: 1, column: 5, length: 7, value: 'test123' },
-                { type: 'newline', position: 11, line: 1, column: 12, length: 1, value: '\n' },
-                { type: 'identifier', position: 12, line: 2, column: 1, length: 3, value: 'bar' },
-                { type: 'operator', position: 15, line: 2, column: 4, length: 1, value: '=' },
-                { type: 'literal', position: 16, line: 2, column: 5, length: 7, value: 'test456' }
-            ] as Token[])
-        })
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([
+        { type: 'identifier', position: 0, line: 1, column: 1, length: 4, value: 'this' },
+        { type: 'operator', position: 4, line: 1, column: 5, length: 1, value: '=' },
+        { type: 'quote', position: 5, line: 1, column: 6, length: 1, value: '"' },
+        { type: 'literal', position: 6, line: 1, column: 7, length: 63, value: `{\n    is: {\n        a: ['multi-line', 'json', 'string']\n    }\n}` },
+        { type: 'quote', position: 69, line: 1, column: 70, length: 1, value: '"' }
+      ] as Token[])
     })
+
+    test('that comments cannot exist in quoted literals', () => {
+      const envFile =
+        `valA="#a comment"
+valB='# another one'`
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([
+        { type: 'identifier', position: 0, line: 1, column: 1, length: 4, value: 'valA' },
+        { type: 'operator', position: 4, line: 1, column: 5, length: 1, value: '=' },
+        { type: 'quote', position: 5, line: 1, column: 6, length: 1, value: '"' },
+        { type: 'literal', position: 6, line: 1, column: 7, length: 10, value: '#a comment' },
+        { type: 'quote', position: 16, line: 1, column: 17, length: 1, value: '"' },
+        { type: 'newline', position: 17, line: 1, column: 18, length: 1, value: '\n' },
+        { type: 'identifier', position: 18, line: 2, column: 1, length: 4, value: 'valB' },
+        { type: 'operator', position: 22, line: 2, column: 5, length: 1, value: '=' },
+        { type: 'quote', position: 23, line: 2, column: 6, length: 1, value: "'" },
+        { type: 'literal', position: 24, line: 2, column: 7, length: 13, value: '# another one' },
+        { type: 'quote', position: 37, line: 2, column: 20, length: 1, value: "'" }
+      ] as Token[])
+    })
+
+    test('that comments can exist on the same line as a variable assignment', () => {
+      const envFile = 'foo=bar # hello world'
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([
+        { type: 'identifier', position: 0, line: 1, column: 1, length: 3, value: 'foo' },
+        { type: 'operator', position: 3, line: 1, column: 4, length: 1, value: '=' },
+        { type: 'literal', position: 4, line: 1, column: 5, length: 3, value: 'bar' },
+        { type: 'whitespace', position: 7, line: 1, column: 8, length: 1, value: ' ' },
+        { type: 'comment', position: 8, line: 1, column: 9, length: 1, value: '#' },
+        { type: 'commentBody', position: 9, line: 1, column: 10, length: 12, value: ' hello world' }
+      ] as Token[])
+    })
+
+    test('that newlines terminate variable assignment when the literal value is unqouted', () => {
+      const envFile =
+        `foo=test123
+bar=test456`
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([
+        { type: 'identifier', position: 0, line: 1, column: 1, length: 3, value: 'foo' },
+        { type: 'operator', position: 3, line: 1, column: 4, length: 1, value: '=' },
+        { type: 'literal', position: 4, line: 1, column: 5, length: 7, value: 'test123' },
+        { type: 'newline', position: 11, line: 1, column: 12, length: 1, value: '\n' },
+        { type: 'identifier', position: 12, line: 2, column: 1, length: 3, value: 'bar' },
+        { type: 'operator', position: 15, line: 2, column: 4, length: 1, value: '=' },
+        { type: 'literal', position: 16, line: 2, column: 5, length: 7, value: 'test456' }
+      ] as Token[])
+    })
+
+    test('that quoted values can be empty', () => {
+      const envFile = `emptyUnquoted=
+emptySingleQuoted=''
+emptyDoubleQuoted=""
+fullUnquoted=hello
+fullSingleQuoted='some stuff'
+fullDoubleQuoted="some other stuff"
+`
+      const tokens = analyzeEnvSourceCode(envFile)
+      expect(tokens).toEqual([
+        {
+          type: TokenType.identifier,
+          position: 0,
+          line: 1,
+          column: 1,
+          length: 13,
+          value: "emptyUnquoted",
+        },
+        {
+          type: TokenType.operator,
+          position: 13,
+          line: 1,
+          column: 14,
+          length: 1,
+          value: "=",
+        },
+        {
+          type: TokenType.newline,
+          position: 14,
+          line: 1,
+          column: 15,
+          length: 1,
+          value: "\n",
+        },
+        {
+          type: TokenType.identifier,
+          position: 15,
+          line: 2,
+          column: 1,
+          length: 17,
+          value: "emptySingleQuoted",
+        },
+        {
+          type: TokenType.operator,
+          position: 32,
+          line: 2,
+          column: 18,
+          length: 1,
+          value: "=",
+        },
+        {
+          type: TokenType.quote,
+          position: 33,
+          line: 2,
+          column: 19,
+          length: 1,
+          value: "'",
+        },
+        {
+          type: TokenType.quote,
+          position: 34,
+          line: 2,
+          column: 20,
+          length: 1,
+          value: "'",
+        },
+        {
+          type: TokenType.newline,
+          position: 35,
+          line: 2,
+          column: 21,
+          length: 1,
+          value: "\n",
+        },
+        {
+          type: TokenType.identifier,
+          position: 36,
+          line: 3,
+          column: 1,
+          length: 17,
+          value: "emptyDoubleQuoted",
+        },
+        {
+          type: TokenType.operator,
+          position: 53,
+          line: 3,
+          column: 18,
+          length: 1,
+          value: "=",
+        },
+        {
+          type: TokenType.quote,
+          position: 54,
+          line: 3,
+          column: 19,
+          length: 1,
+          value: "\"",
+        },
+        {
+          type: TokenType.quote,
+          position: 55,
+          line: 3,
+          column: 20,
+          length: 1,
+          value: "\"",
+        },
+        {
+          type: TokenType.newline,
+          position: 56,
+          line: 3,
+          column: 21,
+          length: 1,
+          value: "\n",
+        },
+        {
+          type: TokenType.identifier,
+          position: 57,
+          line: 4,
+          column: 1,
+          length: 12,
+          value: "fullUnquoted",
+        },
+        {
+          type: TokenType.operator,
+          position: 69,
+          line: 4,
+          column: 13,
+          length: 1,
+          value: "=",
+        },
+        {
+          type: TokenType.literal,
+          position: 70,
+          line: 4,
+          column: 14,
+          length: 5,
+          value: "hello",
+        },
+        {
+          type: TokenType.newline,
+          position: 75,
+          line: 4,
+          column: 19,
+          length: 1,
+          value: "\n",
+        },
+        {
+          type: TokenType.identifier,
+          position: 76,
+          line: 5,
+          column: 1,
+          length: 16,
+          value: "fullSingleQuoted",
+        },
+        {
+          type: TokenType.operator,
+          position: 92,
+          line: 5,
+          column: 17,
+          length: 1,
+          value: "=",
+        },
+        {
+          type: TokenType.quote,
+          position: 93,
+          line: 5,
+          column: 18,
+          length: 1,
+          value: "'",
+        },
+        {
+          type: TokenType.literal,
+          position: 94,
+          line: 5,
+          column: 19,
+          length: 10,
+          value: "some stuff",
+        },
+        {
+          type: TokenType.quote,
+          position: 104,
+          line: 5,
+          column: 29,
+          length: 1,
+          value: "'",
+        },
+        {
+          type: TokenType.newline,
+          position: 105,
+          line: 5,
+          column: 30,
+          length: 1,
+          value: "\n",
+        },
+        {
+          type: TokenType.identifier,
+          position: 106,
+          line: 6,
+          column: 1,
+          length: 16,
+          value: "fullDoubleQuoted",
+        },
+        {
+          type: TokenType.operator,
+          position: 122,
+          line: 6,
+          column: 17,
+          length: 1,
+          value: "=",
+        },
+        {
+          type: TokenType.quote,
+          position: 123,
+          line: 6,
+          column: 18,
+          length: 1,
+          value: "\"",
+        },
+        {
+          type: TokenType.literal,
+          position: 124,
+          line: 6,
+          column: 19,
+          length: 16,
+          value: "some other stuff",
+        },
+        {
+          type: TokenType.quote,
+          position: 140,
+          line: 6,
+          column: 35,
+          length: 1,
+          value: "\"",
+        },
+        {
+          type: TokenType.newline,
+          position: 141,
+          line: 6,
+          column: 36,
+          length: 1,
+          value: "\n",
+        },
+      ] as Token[])
+    })
+  })
 })

--- a/test/unit/lib/env/renderer.test.ts
+++ b/test/unit/lib/env/renderer.test.ts
@@ -1,0 +1,120 @@
+import {
+  DocumentNode,
+  NodeType,
+  QuoteType,
+} from "../../../../src/lib/env/parser";
+import { render } from "../../../../src/lib/env/renderer";
+
+describe(".env renderer", () => {
+  test("that variable declarations without a body can be rendered", () => {
+    const abstractSyntaxTree: DocumentNode = {
+      type: NodeType.document,
+      statements: [
+        {
+          type: NodeType.variableDeclaration,
+          identifier: { type: NodeType.identifier, name: "EMPTY" },
+        },
+      ],
+    };
+    const document = render(abstractSyntaxTree);
+    expect(document).toEqual("EMPTY=");
+  });
+
+  test("that variable declarations with unquoted bodies can be rendered", () => {
+    const abstractSyntaxTree: DocumentNode = {
+      type: NodeType.document,
+      statements: [
+        {
+          type: NodeType.variableDeclaration,
+          identifier: { type: NodeType.identifier, name: "RAW" },
+          value: { type: NodeType.literal, value: "value" },
+        },
+      ],
+    };
+    const document = render(abstractSyntaxTree);
+    expect(document).toEqual("RAW=value");
+  });
+
+  test("that variable declarations with double-quoted bodies can be rendered", () => {
+    const abstractSyntaxTree: DocumentNode = {
+      type: NodeType.document,
+      statements: [
+        {
+          type: NodeType.variableDeclaration,
+          identifier: { type: NodeType.identifier, name: "GIMME" },
+          value: {
+            type: NodeType.quotedLiteral,
+            quoteType: QuoteType.double,
+            content: { type: NodeType.identifier, value: "double quotes" },
+          },
+        },
+      ],
+    };
+    const document = render(abstractSyntaxTree);
+    expect(document).toEqual('GIMME="double quotes"');
+  });
+
+  test("that variable declarations with single-quoted bodies can be rendered", () => {
+    const abstractSyntaxTree: DocumentNode = {
+      type: NodeType.document,
+      statements: [
+        {
+          type: NodeType.variableDeclaration,
+          identifier: { type: NodeType.identifier, name: "theseAre" },
+          value: {
+            type: NodeType.quotedLiteral,
+            quoteType: QuoteType.single,
+            content: { type: NodeType.identifier, value: "single quotes" },
+          },
+        },
+      ],
+    };
+    const document = render(abstractSyntaxTree);
+    expect(document).toEqual("theseAre='single quotes'");
+  });
+
+  test("that comments with bodies can be rendered", () => {
+    const abstractSyntaxTree: DocumentNode = {
+      type: NodeType.document,
+      statements: [{ type: NodeType.comment, body: " this is a comment" }],
+    };
+    const document = render(abstractSyntaxTree);
+    expect(document).toEqual("# this is a comment");
+  });
+
+  test("that comments with no body can be rendered", () => {
+    const abstractSyntaxTree: DocumentNode = {
+      type: NodeType.document,
+      statements: [{ type: NodeType.comment, body: null }],
+    };
+    const document = render(abstractSyntaxTree);
+    expect(document).toEqual("#");
+  });
+
+  test("that empty syntax trees render nothing", () => {
+    const abstractSyntaxTree: DocumentNode = {
+      type: NodeType.document,
+      statements: [],
+    };
+    const document = render(abstractSyntaxTree);
+    expect(document).toEqual("");
+  });
+
+  test("that newlines can be rendered", () => {
+    const abstractSyntaxTree: DocumentNode = {
+      type: NodeType.document,
+      statements: [{type: NodeType.newline}],
+    };
+    const document = render(abstractSyntaxTree);
+    expect(document).toEqual("\n");
+  });
+
+  test("that empty syntax trees render nothing", () => {
+    const abstractSyntaxTree: DocumentNode = {
+      type: NodeType.document,
+      statements: [],
+    };
+    const document = render(abstractSyntaxTree);
+    expect(document).toEqual("");
+  });
+});

--- a/test/unit/lib/options.test.ts
+++ b/test/unit/lib/options.test.ts
@@ -7,7 +7,7 @@ describe("options", () => {
             '/home/bkotos/Projects/env-prompt/dist/index.js'
         ]
         const options = getOptionsFromRawArguments(argv)
-        expect(options).toEqual({distFilePath: '.env.dist', localFilePath: '.env'})
+        expect(options).toEqual({distFilePath: '.env.dist', localFilePath: '.env', prompts: true})
     });
 
     test('that the localFilePath option can be overridden with -l', () => {
@@ -18,7 +18,7 @@ describe("options", () => {
             'prod.env'
         ]
         const options = getOptionsFromRawArguments(argv)
-        expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: 'prod.env' })
+        expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: 'prod.env', prompts: true })
     });
 
     test('that the localFilePath option can be overridden with --localFile', () => {
@@ -29,7 +29,7 @@ describe("options", () => {
             'dev.env'
         ]
         const options = getOptionsFromRawArguments(argv)
-        expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: 'dev.env' })
+        expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: 'dev.env', prompts: true })
     });
 
     test('that the distFilePath option can be overridden with --distFile', () => {
@@ -40,7 +40,7 @@ describe("options", () => {
             'common.env'
         ]
         const options = getOptionsFromRawArguments(argv)
-        expect(options).toEqual({ distFilePath: 'common.env', localFilePath: '.env' })
+        expect(options).toEqual({ distFilePath: 'common.env', localFilePath: '.env', prompts: true })
     });
 
     test('that the distFilePath option can be overridden with --distFile', () => {
@@ -51,6 +51,36 @@ describe("options", () => {
             'shared.env'
         ]
         const options = getOptionsFromRawArguments(argv)
-        expect(options).toEqual({ distFilePath: 'shared.env', localFilePath: '.env' })
+        expect(options).toEqual({ distFilePath: 'shared.env', localFilePath: '.env', prompts: true })
+    });
+
+    test('that --prompts sets the prompts option to true', () => {
+        const argv = [
+            '/home/bkotos/.nvm/versions/node/v12.18.0/bin/node',
+            '/home/bkotos/Projects/env-prompt/dist/index.js',
+            '--prompts'
+        ]
+        const options = getOptionsFromRawArguments(argv)
+        expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: '.env', prompts: true })
+    });
+
+    test('that --prompts=true sets the prompts option to true', () => {
+        const argv = [
+            '/home/bkotos/.nvm/versions/node/v12.18.0/bin/node',
+            '/home/bkotos/Projects/env-prompt/dist/index.js',
+            '--prompts=true'
+        ]
+        const options = getOptionsFromRawArguments(argv)
+        expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: '.env', prompts: true })
+    });
+
+    test('that --prompts=false sets the prompts option to false', () => {
+        const argv = [
+            '/home/bkotos/.nvm/versions/node/v12.18.0/bin/node',
+            '/home/bkotos/Projects/env-prompt/dist/index.js',
+            '--prompts=false'
+        ]
+        const options = getOptionsFromRawArguments(argv)
+        expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: '.env', prompts: false })
     });
 });

--- a/test/unit/lib/options.test.ts
+++ b/test/unit/lib/options.test.ts
@@ -1,4 +1,4 @@
-import { getOptionsFromRawArguments } from "../../../src/lib/options";
+import { getOptionsFromEnvironment } from "../../../src/lib/options";
 
 describe("options", () => {
     test('that a default set of options is retrieved when no CLI arguments are provided', () => {
@@ -6,7 +6,8 @@ describe("options", () => {
             '/home/bkotos/.nvm/versions/node/v12.18.0/bin/node',
             '/home/bkotos/Projects/env-prompt/dist/index.js'
         ]
-        const options = getOptionsFromRawArguments(argv)
+        const processEnv = {}
+        const options = getOptionsFromEnvironment(argv, processEnv)
         expect(options).toEqual({distFilePath: '.env.dist', localFilePath: '.env', prompts: true})
     });
 
@@ -17,7 +18,8 @@ describe("options", () => {
             '-l',
             'prod.env'
         ]
-        const options = getOptionsFromRawArguments(argv)
+        const processEnv = {}
+        const options = getOptionsFromEnvironment(argv, processEnv)
         expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: 'prod.env', prompts: true })
     });
 
@@ -28,7 +30,8 @@ describe("options", () => {
             '--localFile',
             'dev.env'
         ]
-        const options = getOptionsFromRawArguments(argv)
+        const processEnv = {}
+        const options = getOptionsFromEnvironment(argv, processEnv)
         expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: 'dev.env', prompts: true })
     });
 
@@ -39,7 +42,8 @@ describe("options", () => {
             '-d',
             'common.env'
         ]
-        const options = getOptionsFromRawArguments(argv)
+        const processEnv = {}
+        const options = getOptionsFromEnvironment(argv, processEnv)
         expect(options).toEqual({ distFilePath: 'common.env', localFilePath: '.env', prompts: true })
     });
 
@@ -50,7 +54,8 @@ describe("options", () => {
             '--distFile',
             'shared.env'
         ]
-        const options = getOptionsFromRawArguments(argv)
+        const processEnv = {}
+        const options = getOptionsFromEnvironment(argv, processEnv)
         expect(options).toEqual({ distFilePath: 'shared.env', localFilePath: '.env', prompts: true })
     });
 
@@ -60,7 +65,8 @@ describe("options", () => {
             '/home/bkotos/Projects/env-prompt/dist/index.js',
             '--prompts'
         ]
-        const options = getOptionsFromRawArguments(argv)
+        const processEnv = {}
+        const options = getOptionsFromEnvironment(argv, processEnv)
         expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: '.env', prompts: true })
     });
 
@@ -70,7 +76,8 @@ describe("options", () => {
             '/home/bkotos/Projects/env-prompt/dist/index.js',
             '--prompts=true'
         ]
-        const options = getOptionsFromRawArguments(argv)
+        const processEnv = {}
+        const options = getOptionsFromEnvironment(argv, processEnv)
         expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: '.env', prompts: true })
     });
 
@@ -80,7 +87,39 @@ describe("options", () => {
             '/home/bkotos/Projects/env-prompt/dist/index.js',
             '--prompts=false'
         ]
-        const options = getOptionsFromRawArguments(argv)
+        const processEnv = {}
+        const options = getOptionsFromEnvironment(argv, processEnv)
         expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: '.env', prompts: false })
+    });
+
+    test('that CI=false in process.env sets the prompts option to true', () => {
+        const argv = [
+            '/home/bkotos/.nvm/versions/node/v12.18.0/bin/node',
+            '/home/bkotos/Projects/env-prompt/dist/index.js'
+        ]
+        const processEnv = { CI: 'false' }
+        const options = getOptionsFromEnvironment(argv, processEnv)
+        expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: '.env', prompts: true })
+    });
+
+    test('that CI=true in process.env sets the prompts option to false', () => {
+        const argv = [
+            '/home/bkotos/.nvm/versions/node/v12.18.0/bin/node',
+            '/home/bkotos/Projects/env-prompt/dist/index.js'
+        ]
+        const processEnv = { CI: 'true' }
+        const options = getOptionsFromEnvironment(argv, processEnv)
+        expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: '.env', prompts: false })
+    });
+
+    test('that CI=true in process.env and --prompts sets the prompts option to true', () => {
+        const argv = [
+            '/home/bkotos/.nvm/versions/node/v12.18.0/bin/node',
+            '/home/bkotos/Projects/env-prompt/dist/index.js',
+            '--prompts'
+        ]
+        const processEnv = { CI: 'true' }
+        const options = getOptionsFromEnvironment(argv, processEnv)
+        expect(options).toEqual({ distFilePath: '.env.dist', localFilePath: '.env', prompts: true })
     });
 });


### PR DESCRIPTION
With these changes, env-prompt now fully function after the functional rewrite (no pun intended).  I still need to finish unit test coverage, for the merger and parser.  This will be in a follow-up PR.

Change summary:
- Implement VS Code debugger for lexer unit tests
- Add CI check
- Implement .env renderer, which converts an AST to a .env string
- Implement .env merger, which combines two ASTs
- Fix bug where .env lexer for empty single quotes was putting the entire document into a literal token
- Refactor options parsing logic to be less magic